### PR TITLE
BugFix For Express.js Unable To Connect To Postgres via Docker

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -4,5 +4,5 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres?schema=public"
+DATABASE_URL="postgresql://postgres:postgres@postgres:5432/postgres?schema=public"
 HCRIPTO_SECRET="6b209cdb-07c1-4fc9-aea4-42057f04aa8c"

--- a/app/app/db-connection.js
+++ b/app/app/db-connection.js
@@ -5,7 +5,7 @@
 const pgp = require('pg-promise')();
 
 const cn = {
-    host: 'localhost', // the service name from docker-compose.yml
+    host: 'db', // the service name from docker-compose.yml
     port: 5432,
     database: 'postgres', 
     user: 'postgres',


### PR DESCRIPTION
Changed db-connect file to connect to the postgres service name, db, rather than localhost, since docker to docker connections have to be managed via the Docker network.