### PR TITLE
Dockerization WebSockets BugFix

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -64,6 +64,9 @@ services:
       - .:/app
     ports:
       - "6969:6969"
+      - "7979:7979"
+
+      
 
 volumes:
   pgdata:


### PR DESCRIPTION
Includes an extra port mapping in the express container file in order to ensure the WebSocket port, which is 7979, in the container has a mapping to the machine port, ensuring that the browser, and, by extension, other machines, are able to access the WSS port in the express container. 